### PR TITLE
Implement bytes visitor for deserializing SecretKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,7 +499,7 @@ impl<'de> de::Visitor<'de> for SecretKeyStrVisitor {
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
-            .write_str("a bytestring of 32 bytes in length")
+            .write_str("a bytestring 32 bytes in length")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -507,7 +507,6 @@ impl<'de> de::Visitor<'de> for SecretKeyStrVisitor {
         E: de::Error,
     {
         let value: &[u8] = &base64::decode(value).map_err(|e| E::custom(e))?;
-        println!("value len: {:?}", value.len());
         // let key_format = match value.len() {
         //     33 => PublicKeyFormat::Compressed,
         //     64 => PublicKeyFormat::Raw,
@@ -527,7 +526,7 @@ impl<'de> de::Visitor<'de> for SecretKeyBytesVisitor {
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
-            .write_str("a bytestring of 32 bytes in length")
+            .write_str("a byte slice 32 bytes in length")
     }
 
     fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,8 +498,7 @@ impl<'de> de::Visitor<'de> for SecretKeyStrVisitor {
     type Value = SecretKey;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter
-            .write_str("a bytestring 32 bytes in length")
+        formatter.write_str("a bytestring 32 bytes in length")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -525,8 +524,7 @@ impl<'de> de::Visitor<'de> for SecretKeyBytesVisitor {
     type Value = SecretKey;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter
-            .write_str("a byte slice 32 bytes in length")
+        formatter.write_str("a byte slice 32 bytes in length")
     }
 
     fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>


### PR DESCRIPTION
# What

Similar to https://github.com/paritytech/libsecp256k1/pull/110/files, do for `SecretKey`. Implement a `SecretKeyBytesVisitor` and use it when using binary-esque serde methods (ie. `bincode`). In other cases, use `SecretKeyStrVisitor`. 

This is necessary in order to fix deserialization in the integration tests of https://github.com/LIT-Protocol/lit_node_rust/